### PR TITLE
ページのチェック・修正

### DIFF
--- a/app/views/items/detail.html.haml
+++ b/app/views/items/detail.html.haml
@@ -24,7 +24,7 @@
           %ul.header-user-nav
             %li
               = link_to root_path, class: "icons" do
-                %img.user-icon{src: "/assets/member_photo_noimage_thumb.png"}
+                = image_tag (asset_path "member_photo_noimage_thumb.png"), class: "user-icon"
                 %span.icon-text
                   マイページ
             %li


### PR DESCRIPTION
表題の通りです。
/assets/~では本番環境において画像が表示されない問題を解消するため、
image_tag~を用いた表現へと変更しました。