### PR TITLE
Master

### DIFF
--- a/app/views/cards/registrate.html.haml
+++ b/app/views/cards/registrate.html.haml
@@ -1,6 +1,6 @@
 .member-ship__wrapper
   = link_to root_path do
-    = image_tag (asset_path 'phone_header')
+    = image_tag (asset_path 'phone_header.png')
 
 .card__wrapper__top
   %section.card__input--text

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,6 @@
 .member-ship__wrapper
   = link_to root_path do
-    = image_tag (asset_path 'phone_header')
+    = image_tag (asset_path 'phone_header.png')
 
   .person__rbox__top
     %section.person__rbox__container.identification__user


### PR DESCRIPTION
what
image_tag部分の記述の修正
why
「phone_header」の拡張子部分「.png」が抜けている点を修正するため