### PR TITLE
再設定用

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-server '52.194.135.75', user: 'ec2-user', roles: %w{app db web}
+server '13.112.122.153', user: 'ec2-user', roles: %w{app db web}
 
 set :rails_env, "production"
 set :unicorn_rack_env, "production"


### PR DESCRIPTION
what
接続先を変更した
why
EC2インスタンスの再設定、ErasticIPを再取得したため